### PR TITLE
Fix: ColumnCalculator's buttons missed React key

### DIFF
--- a/src/ColumnCalculator.tsx
+++ b/src/ColumnCalculator.tsx
@@ -94,6 +94,7 @@ export function ColumnCalculator({
           const key = `${suit}-${value}` as ExpeditionCard;
           return (
             <button
+              key={key}
               className={classNames(styles.button, styles.expeditionCard, {
                 [styles.buttonActive]: expeditions[key],
               })}


### PR DESCRIPTION
React was yielding a warning about the missing `key` element in the component's children.

```
Warning: Each child in a list should have a unique "key" prop.

Check the render method of `ColumnCalculator`. See https://reactjs.org/link/warning-keys for more information.
```